### PR TITLE
contrib/collect-netscaler: read config from stdin by default

### DIFF
--- a/contrib/collect-netscaler/config/config.go
+++ b/contrib/collect-netscaler/config/config.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	aflag    = flag.String("a", "./auth", "username and password, json-encoded file")
+	aflag    = flag.String("a", "/dev/stdin", "username and password, json-encoded file")
 	Verbose  = flag.Bool("v", false, "verbose mode")
 	Interval = flag.Duration("i", 7*time.Second, "poll interval")
 	unsafe   = flag.Bool("u", false, "disable tls")

--- a/contrib/collect-netscaler/dist/collector.1
+++ b/contrib/collect-netscaler/dist/collector.1
@@ -32,7 +32,7 @@ branch of the metrics hierarchy.
 Set path to a file containing the authentication secret.  The file
 contains single JSON object with string properties: Username,
 Password. The default path is
-.BR ./auth .
+.BR /dev/stdin .
 .RE
 .P
 .BI -i " interval"
@@ -56,7 +56,7 @@ Poll netscaler01.example.com using the given auth credentials:
 .nf
 #!/bin/bash
 
-exec collect-netscaler -a /dev/stdin netscaler01.example.com << 'EOF'
+exec collect-netscaler netscaler01.example.com << 'EOF'
 {
         "Username": "opentsp",
         "Password": "13donkeys"


### PR DESCRIPTION
The previous default predates tsp-poller and makes less sense now.