### PR TITLE
cmd/tsp-controller: obsolete <poller>

### DIFF
--- a/cmd/tsp-controller/config/network/network.go
+++ b/cmd/tsp-controller/config/network/network.go
@@ -48,7 +48,6 @@ type Config struct {
 
 	// Network topology.
 	Aggregator *Aggregator
-	Poller     *Poller
 	Subscriber []*Subscriber
 }
 
@@ -89,14 +88,13 @@ func ReadFile(path string) (*Config, error) {
 	var f struct {
 		Restrict   []*Restriction `xml:"restrict"`
 		Aggregator *Aggregator    `xml:"aggregator"`
-		Poller     *Poller        `xml:"poller"`
 		Subscriber []*Subscriber  `xml:"subscriber"`
 	}
 	r := bytes.NewBuffer(buf)
 	if err := xml.NewDecoder(r).Decode(&f); err != nil {
 		return nil, fmt.Errorf("error decoding %s: %v", path, err)
 	}
-	config := Config{f.Restrict, f.Aggregator, f.Poller, f.Subscriber}
+	config := Config{f.Restrict, f.Aggregator, f.Subscriber}
 	if len(config.restrict) == 0 {
 		config.restrict = DefaultRestrictions
 	}
@@ -140,11 +138,6 @@ func (r *Restriction) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) err
 // Aggregator specifies the aggregator node, a node that exports the
 // indirect site feed.
 type Aggregator struct {
-	Host string `xml:"host,attr"`
-}
-
-// Poller represents the poller node, a node that masquerades many remote devices.
-type Poller struct {
 	Host string `xml:"host,attr"`
 }
 

--- a/cmd/tsp-controller/config/network/network_test.go
+++ b/cmd/tsp-controller/config/network/network_test.go
@@ -29,16 +29,12 @@ var testUnmarshal = []struct {
 <network>
 	<restrict host="foo"/>
 	<aggregator host="ahost"/>
-	<poller host="phost"/>
 	<subscriber id="s" host="shost" direct="true" dedup="true"/>
 </network>
 `,
 		out: Config{
 			Aggregator: &Aggregator{
 				Host: "ahost",
-			},
-			Poller: &Poller{
-				Host: "phost",
 			},
 			Subscriber: []*Subscriber{
 				{

--- a/cmd/tsp-controller/control/tsp-forwarder/control.go
+++ b/cmd/tsp-controller/control/tsp-forwarder/control.go
@@ -187,16 +187,8 @@ func subscribers(config *config.Config, match func(*network.Subscriber) bool) []
 // TODO(masiulaniec): make this configurable.
 const pollerMaxConnsPerHost = 12
 
-func isPoller(host string, config *config.Config) bool {
-	poller := config.Network.Poller
-	return poller != nil && poller.Host == host
-}
-
 // pollerView returns a tsp-poller(8) view.
 func (h *handler) pollerView(key *Key) (*View, error) {
-	if !isPoller(key.Host, h.config) {
-		return nil, fmt.Errorf("not a poller: %v", key.Host)
-	}
 	view, err := newView(key, h.config)
 	if err != nil {
 		return nil, err

--- a/cmd/tsp-controller/dist/service.8
+++ b/cmd/tsp-controller/dist/service.8
@@ -149,12 +149,6 @@ Address of the host running
 .BI tsp-aggregator (8)
 .RE
 .P
-.BI "<poller host=" host "/>"
-.RS
-Address of the host running
-.BI tsp-poller (8)
-.RE
-.P
 .BI "<restrict host=" host "/>"
 .RS
 Limit controller's scope. Handle requests only for hosts matching the


### PR DESCRIPTION
Allow any number of pollers (was 1).

Fixes issue #22