### PR TITLE
collect-netscaler: change auth URL

### DIFF
--- a/contrib/collect-netscaler/nitro/client.go
+++ b/contrib/collect-netscaler/nitro/client.go
@@ -265,7 +265,7 @@ func (c *cookie) String() string {
 
 func newCookie(c *Client) (*http.Cookie, error) {
 	var r responseSessionID
-	req := newSessionRequest(c.url(), c.auth.username, c.auth.password)
+	req := newSessionRequest(c.url()+"/config/login", c.auth.username, c.auth.password)
 	if err := c.roundtrip(&r, req); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change makes collect-netscaler compatible with NetScaler versions 9.3 to 10.5

This is a proposed fix for #29.