### PR TITLE
Add missing Block logic

### DIFF
--- a/cmd/tsp-controller/control/tsp-forwarder/control.go
+++ b/cmd/tsp-controller/control/tsp-forwarder/control.go
@@ -71,8 +71,9 @@ type Relay struct {
 
 // Rule corresponds to elements of the Filter setting, see tsp-forwarder(8).
 type Rule struct {
-	Match []string
-	Set   []string
+	Match []string `json:",omitempty"`
+	Set   []string `json:",omitempty"`
+	Block bool     `json:",omitempty"`
 }
 
 // View corresponds to tsp-forwarder configuration file, see tsp-forwarder(8).


### PR DESCRIPTION
Using `Block` with tsp-forwarder (e.g. using the `filter` script) would produce broken configuration.

This change is based on equivalent code in [`control/collect-statse/control.go`](https://github.com/betfair/opentsp/blob/master/cmd/tsp-controller/control/collect-statse/control.go#L62).
