### PR TITLE
umask and malloc default configuration

### DIFF
--- a/cmd/tsp-aggregator/dist/service.init
+++ b/cmd/tsp-aggregator/dist/service.init
@@ -3,6 +3,9 @@
 # chkconfig: 2345 60 40
 # description: TSP aggregator
 
+umask 00022
+export MALLOC_ARENA_MAX=1
+
 . /etc/rc.d/init.d/functions
 . /etc/sysconfig/tsp-aggregator
 

--- a/cmd/tsp-controller/dist/service.init
+++ b/cmd/tsp-controller/dist/service.init
@@ -3,6 +3,9 @@
 # chkconfig: 2345 60 40
 # description: TSDB controller
 
+umask 00022
+export MALLOC_ARENA_MAX=1
+
 . /etc/rc.d/init.d/functions
 . /etc/sysconfig/tsp-controller
 

--- a/cmd/tsp-forwarder/dist/service.init
+++ b/cmd/tsp-forwarder/dist/service.init
@@ -3,6 +3,9 @@
 # chkconfig: 2345 60 40
 # description: TSP forwarder
 
+umask 00022
+export MALLOC_ARENA_MAX=1
+
 . /etc/rc.d/init.d/functions
 . /etc/sysconfig/tsp
 

--- a/cmd/tsp-poller/dist/service.init
+++ b/cmd/tsp-poller/dist/service.init
@@ -3,6 +3,9 @@
 # chkconfig: 2345 60 40
 # description: TSP poller
 
+umask 00022
+export MALLOC_ARENA_MAX=1
+
 . /etc/rc.d/init.d/functions
 . /etc/sysconfig/tsp-poller
 


### PR DESCRIPTION
Setting a relatively permissive umask as default improves log reading in hardened systems.

Setting `MALLOC_ARENA_MAX` is a more controversial change. The number of arenas created by default is `((NUMBER_OF_CPU_CORES) * (sizeof(long) == 4 ? 2 : 8))` and the size of each arena will be 1MB on 32-bit and 64MB on 64-bit. This means that, on a 64-bit system with 16 CPU cores, would'll have _16 x 8 = 128_ arenas that can take up up to _128 x 64MB = 8GB_. This change aims to address this by limiting the number of arenas malloc can create.

You can override both these settings in the respective sysconfig file for each of the tsp components.
