### PR TITLE
Fix client panic when trying to put a tagless point

### DIFF
--- a/internal/tsdb/client.go
+++ b/internal/tsdb/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"hash"
 	"hash/fnv"
+	"log"
 	"net"
 	"strings"
 	"sync"
@@ -195,6 +196,10 @@ func (c cmd) SeriesHash(hash hash.Hash32) int {
 	buf := c.Point()
 	// include Metric
 	i := bytes.IndexByte(buf, ' ')
+	if i < 0 {
+		log.Printf("SeriesHash: invalid buf: %s", string(c.Point()))
+		return 0 // return a default hash
+	}
 	hash.Write(buf[:i])
 	buf = buf[i+1:]
 	// exclude Time
@@ -202,6 +207,10 @@ func (c cmd) SeriesHash(hash hash.Hash32) int {
 	buf = buf[i+1:]
 	// exclude Value
 	i = bytes.IndexByte(buf, ' ')
+	if i < 0 {
+		log.Printf("SeriesHash: invalid buf: %s", string(c.Point()))
+		return 0 // return a default hash
+	}
 	// include Tags
 	hash.Write(buf[i:])
 	// Sum

--- a/internal/tsdb/client.go
+++ b/internal/tsdb/client.go
@@ -196,6 +196,9 @@ func (c cmd) SeriesHash(hash hash.Hash32) int {
 	buf := c.Point()
 	// include Metric
 	i := bytes.IndexByte(buf, ' ')
+	// this should never happen, as an empty Point representation has
+	// 2 space chars, one before the timestamp and another before the value
+	// e.g. " 0 0"
 	if i < 0 {
 		log.Printf("SeriesHash: invalid buf: %s", string(c.Point()))
 		return 0 // return a default hash

--- a/internal/tsdb/client_test.go
+++ b/internal/tsdb/client_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The Sporting Exchange Limited. All rights reserved.
+// Use of this source code is governed by a free license that can be
+// found in the LICENSE file.
+
+package tsdb
+
+import (
+	"hash/fnv"
+	"io/ioutil"
+	"log"
+	"testing"
+)
+
+func silenceLogs() {
+	log.SetOutput(ioutil.Discard) // Silence logs
+}
+
+func TestSeriesHash(t *testing.T) {
+	tests := []struct {
+		point    Point
+		expected int
+	}{
+		{
+			point:    Point{},
+			expected: 0,
+		},
+		{
+			point:    Point{metric: []byte("x")},
+			expected: 0,
+		},
+		{
+			point:    Point{metric: []byte("x"), tags: []byte(" y=y")},
+			expected: 4036,
+		},
+	}
+
+	for _, tt := range tests {
+		cmd := tt.point.put()
+		hash := fnv.New32()
+		if actual := cmd.SeriesHash(hash); actual != tt.expected {
+			t.Errorf("cmd.SeriesHash (%v) => %d, want %d", cmd, actual, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
There are situations where a Point can be created with no tags. When that happens, we get a `panic: runtime error: slice bounds out of range` as in https://play.golang.org/p/dRZGQ4AXeJ

This change adds some protection around invalid data.
