### PR TITLE
Controller dist fixes

### DIFF
--- a/cmd/tsp-controller/Makefile
+++ b/cmd/tsp-controller/Makefile
@@ -18,8 +18,8 @@ build:
 install:
 	install -m 755 -d $(DESTDIR)/etc/init.d
 	install -m 755 dist/service.init $(DESTDIR)/etc/init.d/tsp-controller
-# XXX	install -m 755 -d $(DESTDIR)/etc/logrotate.d
-# XXX	install -m 644 dist/service.logrotate $(DESTDIR)/etc/logrotate.d/tsdb
+	install -m 755 -d $(DESTDIR)/etc/logrotate.d
+	install -m 644 dist/service.logrotate $(DESTDIR)/etc/logrotate.d/tsp-controller
 	install -m 755 -d $(DESTDIR)/etc/sysconfig
 	install -m 755 dist/service.sysconfig $(DESTDIR)/etc/sysconfig/tsp-controller
 	install -m 755 -d $(DESTDIR)/etc/tsp-controller

--- a/cmd/tsp-controller/dist/service.init
+++ b/cmd/tsp-controller/dist/service.init
@@ -34,9 +34,10 @@ stop() {
 }
 
 reload() {
-	pid=$(findproc)
-	kill -HUP $pid
-	return 0
+	if pid=$(findproc)
+	then
+		kill -HUP $pid
+	fi
 }
 
 status() {

--- a/cmd/tsp-controller/dist/service.logrotate
+++ b/cmd/tsp-controller/dist/service.logrotate
@@ -1,0 +1,9 @@
+/var/log/tsp/controller.log {
+	rotate 5
+	daily
+	create 0644 root root
+	sharedscripts
+	postrotate
+		/sbin/service tsp-controller reload
+	endscript
+}

--- a/contrib/rpm/tsp.spec
+++ b/contrib/rpm/tsp.spec
@@ -151,7 +151,7 @@ fi
 %defattr(644,root,root,755)
 %config(noreplace) /etc/sysconfig/tsp-controller
 %attr(0755,root,root) /etc/init.d/tsp-controller
-# %config(noreplace) /etc/logrotate.d/*
+%config(noreplace) /etc/logrotate.d/tsp-controller
 %dir /etc/tsp-controller
 %config(noreplace) /etc/tsp-controller/config
 %attr(0755,root,root) /usr/bin/tsp-controller


### PR DESCRIPTION
- Adds log rotation to tsp-controller log;
- Fixes a bug in tsp-controller init script where running reload when the service is stopped failed (and broke automation).
